### PR TITLE
Port ArtifactRegistryIvyResolver to Scala 3 / sbt 2

### DIFF
--- a/modules/sbt/src/main/scala-3/dev/rolang/sbt/gar/ArtifactRegistryIvyRepository.scala
+++ b/modules/sbt/src/main/scala-3/dev/rolang/sbt/gar/ArtifactRegistryIvyRepository.scala
@@ -1,0 +1,70 @@
+package dev.rolang.sbt.gar
+
+import com.google.api.client.http.{ByteArrayContent, GenericUrl, HttpRequestFactory}
+import dev.rolang.gar.{ArtifactRegistryUrlHandlerFactory, Logger}
+import org.apache.ivy.core.module.descriptor.Artifact
+import org.apache.ivy.plugins.repository.{AbstractRepository, Resource}
+import org.apache.ivy.plugins.repository.url.URLResource
+import org.apache.ivy.plugins.resolver.IBiblioResolver
+import org.apache.ivy.util.Message
+import sbt.librarymanagement.{RawRepository, Resolver}
+
+import java.io.File
+import java.net.URI
+import java.nio.file.{Files, StandardCopyOption}
+
+class ArtifactRegistryIvyRepository(logger: Logger) extends AbstractRepository {
+
+  private lazy val requestFactory: HttpRequestFactory =
+    ArtifactRegistryUrlHandlerFactory.createRequestFactory(logger)
+
+  override def getName: String = "ArtifactRegistry"
+
+  override def getResource(source: String): Resource =
+    new URLResource(URI.create(source).toURL)
+
+  override def get(source: String, destination: File): Unit = {
+    val response = requestFactory.buildGetRequest(toHttpsUrl(source)).execute()
+    val is = response.getContent
+    try Files.copy(is, destination.toPath, StandardCopyOption.REPLACE_EXISTING)
+    finally is.close()
+  }
+
+  override def put(artifact: Artifact, src: File, destination: String, overwrite: Boolean): Unit = {
+    logger.info(s"Uploading artifact to: $destination")
+    val bytes = Files.readAllBytes(src.toPath)
+    requestFactory
+      .buildPutRequest(toHttpsUrl(destination), new ByteArrayContent(null, bytes))
+      .execute()
+  }
+
+  override def list(parent: String): java.util.List[String] =
+    java.util.Collections.emptyList()
+
+  private def toHttpsUrl(raw: String): GenericUrl = {
+    val url = URI.create(raw).toURL
+    val g = new GenericUrl()
+    g.setScheme("https")
+    g.setHost(url.getHost)
+    g.appendRawPath(url.getPath)
+    g
+  }
+}
+
+object ArtifactRegistryIvyResolver {
+
+  def create(name: String, root: String): Resolver = {
+    val logger = new Logger {
+      def info(msg: String): Unit = Message.info(msg)
+      def error(msg: String): Unit = Message.error(msg)
+      def debug(msg: String): Unit = Message.debug(msg)
+    }
+    val resolver = new IBiblioResolver
+    resolver.setName(name)
+    resolver.setRoot(root)
+    resolver.setM2compatible(true)
+    resolver.setUseMavenMetadata(true)
+    resolver.setRepository(new ArtifactRegistryIvyRepository(logger))
+    new RawRepository(resolver, name)
+  }
+}

--- a/modules/sbt/src/main/scala-3/dev/rolang/sbt/gar/GarCompat.scala
+++ b/modules/sbt/src/main/scala-3/dev/rolang/sbt/gar/GarCompat.scala
@@ -29,7 +29,7 @@ object GarCompat:
       },
       publishTo := publishTo.value.map {
         case m: sbt.librarymanagement.MavenRepository if m.root.startsWith("artifactregistry://") =>
-          m
+          ArtifactRegistryIvyResolver.create(m.name, m.root)
         case other => other
       }
     )


### PR DESCRIPTION
## Summary
- The `scala-2.12` (sbt 1.x) source set has `ArtifactRegistryIvyRepository`/`ArtifactRegistryIvyResolver`, a custom Ivy `AbstractRepository` that PUTs artifacts via the Google HTTP client directly. This was never ported to the `scala-3` (sbt 2.x) source set.
- Without it, a plain `artifactregistry://` `publishTo` on sbt 2 falls through to Ivy's stock `URLRepository`, which hardcodes `protocol == "http"` for PUT and throws `UnsupportedOperationException: URL repository only support HTTP PUT at the moment` for any other scheme — even though the JVM-wide URL handler is installed correctly.
- Adds `modules/sbt/src/main/scala-3/dev/rolang/sbt/gar/ArtifactRegistryIvyRepository.scala`, a straight port (only an unused `java.net.URL` import dropped).
- Wires it into `GarCompat`'s scala-3 `publishTo` mapping, restoring parity with the scala-2.12 version: a plain `artifactregistry://` `publishTo` is now automatically wrapped with `ArtifactRegistryIvyResolver` on sbt 2 as well.

## Test plan
- [x] `sbt ++3.8.4 plugin/compile` — compiles cleanly
- [x] `sbt ++2.12.21 plugin/compile` — sbt 1.x cross-build still compiles, unaffected
- [x] `sbt scalafmtCheckAll` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)